### PR TITLE
Only compare value when authorizing delete request

### DIFF
--- a/app/Policies/TaskPolicy.php
+++ b/app/Policies/TaskPolicy.php
@@ -19,6 +19,6 @@ class TaskPolicy
      */
     public function destroy(User $user, Task $task)
     {
-        return $user->id === $task->user_id;
+        return $user->id == $task->user_id;
     }
 }


### PR DESCRIPTION
Sometimes, `$user->id` will be an integer while `$task->user_id` will be a string (was the case when running tests for me). Thus, even though you are deleting a task that belongs to you, the check will return false.
