### PR TITLE
Added old input retrieving on validation failure, as mentioned in docs

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -61,7 +61,7 @@ class TaskController extends Controller
             'name' => $request->name,
         ]);
 
-        return redirect('/tasks');
+        return redirect('/tasks')->withInput();
     }
 
     /**

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -21,7 +21,7 @@
                             <label for="task-name" class="col-sm-3 control-label">Task</label>
 
                             <div class="col-sm-6">
-                                <input type="text" name="name" id="task-name" class="form-control" value="{{ old('task') }}">
+                                <input type="text" name="name" id="task-name" class="form-control" value="{{ old('name') }}">
                             </div>
                         </div>
 


### PR DESCRIPTION
From the beginning of Validation section at https://laravel.com/docs/5.2/quickstart-intermediate#validation: 

> ... we want to redirect the user back to the `/tasks` URL, as well as flash the old input and errors ...
- See also my pull request for correcting the docs: https://github.com/laravel/docs/pull/2179
