### PR TITLE
Cast `$task->user_id` to int (resolves issue #10)

### DIFF
--- a/app/Task.php
+++ b/app/Task.php
@@ -13,6 +13,15 @@ class Task extends Model
      * @var array
      */
     protected $fillable = ['name'];
+    
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'user_id' => 'int',
+    ];
 
     /**
      * Get the user that owns the task.


### PR DESCRIPTION
On MySQL `$task->user_id` being returned as string, causing strict comparison to fail in Policy check.
